### PR TITLE
Use specific version of Scrypto

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,5 +65,5 @@ jobs:
           cargo test --release --all-features
       - name: Test examples
         run: |
-          cargo install --git https://github.com/radixdlt/radixdlt-scrypto simulator
+          cargo install --git https://github.com/radixdlt/radixdlt-scrypto --tag v0.1.1 simulator
           for example in examples/*; do (cd $example && scrypto test); done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,11 @@ nightly = [] # enables optimizations or features requiring nightly rust
 runtime_typechecks = []
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/examples/badburn1/Cargo.toml
+++ b/examples/badburn1/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 scrypto_statictypes = { path = "../../" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/examples/fixburn1/Cargo.toml
+++ b/examples/fixburn1/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 scrypto_statictypes = { path = "../../" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.

--- a/examples/mycomponent/Cargo.toml
+++ b/examples/mycomponent/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 scrypto_statictypes = { path = "../../" }
 
 [dev-dependencies]
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "v0.1.1" }
 
 [profile.release]
 opt-level = 's'     # Optimize for size.


### PR DESCRIPTION
Projects using `scrypto_statictypes` are failing because it's no long compatible with the latest Scrypto. This PR is a quick fix to use a tagged version of Scrypto as dependency temporarily. 